### PR TITLE
Added ISSUE_CARD_ITEMS to order_items in WriteOrderStatus and GetOrderStatus

### DIFF
--- a/method-list/client-to-egon/GetOrderStatus.md
+++ b/method-list/client-to-egon/GetOrderStatus.md
@@ -50,47 +50,49 @@ The method returns the current status information for the order
 
 ## :arrow_forward: Output parameters:
 
-
-| parameter                 |                  |                                    |     format     | description                                                                         |
-|:--------------------------|:-----------------|:-----------------------------------|:--------------:|:------------------------------------------------------------------------------------|
-| `order_original_id`       |                  |                                    |    (String)    | The original order number for the client                                            |
-| `reference_number`        |                  |                                    |    (String)    | Reference Nr. of order                                                              |
-| `order_id`                |                  |                                    |   (Integer)    | Order ID from EGON                                                                  |
-| `status_id`               |                  |                                    |   (Integer)    | EGON status ID                                                                      |
-| `status_name`             |                  |                                    |    (String)    | Status name from EGON                                                               |
-| `api_update_enabled`      |                  |                                    |   (Boolean)    | If update over api in this status is enabled then true otherwise false              |
-| `change_timestamp`        |                  |                                    |   (Datetime)   | Timestamp of state change                                                           |
-| `delivery_id`             |                  |                                    |   (Integer)    | Traffic ID                                                                          |
-| `order_items`             |                  |                                    |    (Object)    | Order items                                                                         |
-|                           | `ITEM_ID`        |                                    |   (Integer)    | ITEM_ID eshop card                                                                  |
-|                           | `COUNT`          |                                    |   (Integer)    | Number of pieces in order                                                           |
-|                           | `COUNT_RESERVED` |                                    |   (Integer)    | Number of reserved pieces in the order                                              |
-| `packages`                |                  |                                    |    (Array)     |                                                                                     |
-|                           | `package_nr`     |                                    |    (String)    | Tracking number                                                                     |
-|                           | `tracking_url`  |                                    |    (String)    | Tracking link                                                                       |
-|                           | `tracking_data`  |                                    |    (Array)     | Field with data from tracking                                                       |
-|                           |                  | `timestamp`                        |   (Datetime)   | Time from state                                                                     |
-|                           |                  | `shipment_status`                  |   (Integer)    | Status code from the codebook                                                       |
-|                           |                  | `shipment_note`                    |    (String)    | The name of the status from the dial                                                |
-|                           |                  | `shipment_status_delivery_company` |    (String)    | Status ID from courier company                                                      |
-|                           |                  | `shipment_note_delivery_company`   |    (String)    | The name of the state from the courier company                                      |
-|                           | `images`         |                                    |    (Array)     | Pictures                                                                            |
-|                           | `weight`         |                                    |   (Integer)    | Weight                                                                              |
-|                           | `width`          |                                    |   (Integer)    | Width                                                                               |
-|                           | `height`         |                                    |   (Integer)    | Height                                                                              |
-|                           | `depth`          |                                    |   (Integer)    | Depth                                                                               |
-|                           | `label`          |                                    |    (String)    | Label                                                                               |
-| `shipp_company_id`        |                  |                                    |   (Integer)    | Id the carrier in the system                                                        |
-| `shipp_company`           |                  |                                    |    (String)    | Shipper                                                                             |
-| `estimated_delivery_time` |                  |                                    |     (Date)     | Assumption date of delivery                                                         |
-| `total_cost`              |                  |                                    |   (Decimal)    | Total expense                                                                       |
-| `cost_by_item`            |                  |                                    |    (Array)     | Costs per individual items                                                          |
-|                           | `item_id`        |                                    |   (Integer)    |                                                                                     |
-|                           | `name`           |                                    |    (String)    |                                                                                     |
-|                           | `price`          |                                    |   (Decimal)    |                                                                                     |
-| `order_errors`            |                  |                                    |    (Array)     | Wrong order parameters                                                              |
-| `invoice_url`             |                  |                                    | (String/null)  | Order invoice url                                                                   |
-| `invoice_id`              |                  |                                    | (Integer/null) | Order invoice id (specific for invoicing system)                                    |     
+| parameter                 |                    |                                    |     format     | description                                                            |
+|:--------------------------|:-------------------|:-----------------------------------|:--------------:|:-----------------------------------------------------------------------|
+| `order_original_id`       |                    |                                    |    (String)    | The original order number for the client                               |
+| `reference_number`        |                    |                                    |    (String)    | Reference Nr. of order                                                 |
+| `order_id`                |                    |                                    |   (Integer)    | Order ID from EGON                                                     |
+| `status_id`               |                    |                                    |   (Integer)    | EGON status ID                                                         |
+| `status_name`             |                    |                                    |    (String)    | Status name from EGON                                                  |
+| `api_update_enabled`      |                    |                                    |   (Boolean)    | If update over api in this status is enabled then true otherwise false |
+| `change_timestamp`        |                    |                                    |   (Datetime)   | Timestamp of state change                                              |
+| `delivery_id`             |                    |                                    |   (Integer)    | Traffic ID                                                             |
+| `order_items`             |                    |                                    |    (Object)    | Order items                                                            |
+|                           | `ITEM_ID`          |                                    |   (Integer)    | ITEM_ID eshop card                                                     |
+|                           | `COUNT`            |                                    |   (Integer)    | Number of pieces in order                                              |
+|                           | `COUNT_RESERVED`   |                                    |   (Integer)    | Number of reserved pieces in the order                                 |
+|                           | `ISSUE_CARD_ITEMS` |                                    |    (Array)     | array of items in issue card                                           |
+|                           |                    | `INVENTORY_ID`                     |   (Integer)    | Inventory ID of the warehouse card                                     |
+|                           |                    | `QR_CODE`                          | (String/null)  | QR code (if have) of he item                                           |
+| `packages`                |                    |                                    |    (Array)     |                                                                        |
+|                           | `package_nr`       |                                    |    (String)    | Tracking number                                                        |
+|                           | `tracking_url`     |                                    |    (String)    | Tracking link                                                          |
+|                           | `tracking_data`    |                                    |    (Array)     | Field with data from tracking                                          |
+|                           |                    | `timestamp`                        |   (Datetime)   | Time from state                                                        |
+|                           |                    | `shipment_status`                  |   (Integer)    | Status code from the codebook                                          |
+|                           |                    | `shipment_note`                    |    (String)    | The name of the status from the dial                                   |
+|                           |                    | `shipment_status_delivery_company` |    (String)    | Status ID from courier company                                         |
+|                           |                    | `shipment_note_delivery_company`   |    (String)    | The name of the state from the courier company                         |
+|                           | `images`           |                                    |    (Array)     | Pictures                                                               |
+|                           | `weight`           |                                    |   (Integer)    | Weight                                                                 |
+|                           | `width`            |                                    |   (Integer)    | Width                                                                  |
+|                           | `height`           |                                    |   (Integer)    | Height                                                                 |
+|                           | `depth`            |                                    |   (Integer)    | Depth                                                                  |
+|                           | `label`            |                                    |    (String)    | Label                                                                  |
+| `shipp_company_id`        |                    |                                    |   (Integer)    | Id the carrier in the system                                           |
+| `shipp_company`           |                    |                                    |    (String)    | Shipper                                                                |
+| `estimated_delivery_time` |                    |                                    |     (Date)     | Assumption date of delivery                                            |
+| `total_cost`              |                    |                                    |   (Decimal)    | Total expense                                                          |
+| `cost_by_item`            |                    |                                    |    (Array)     | Costs per individual items                                             |
+|                           | `item_id`          |                                    |   (Integer)    |                                                                        |
+|                           | `name`             |                                    |    (String)    |                                                                        |
+|                           | `price`            |                                    |   (Decimal)    |                                                                        |
+| `order_errors`            |                    |                                    |    (Array)     | Wrong order parameters                                                 |
+| `invoice_url`             |                    |                                    | (String/null)  | Order invoice url                                                      |
+| `invoice_id`              |                    |                                    | (Integer/null) | Order invoice id (specific for invoicing system)                       |     
 
 ### Sample response
 
@@ -116,7 +118,13 @@ The method returns the current status information for the order
         {
           "ITEM_ID": 123,
           "COUNT": 1,
-          "COUNT_RESERVED": 1
+          "COUNT_RESERVED": 1,
+          "ISSUE_CARD_ITEMS": [
+            {
+              "INVENTORY_ID": 321,
+              "QR_CODE": "xyz"
+            }
+          ]
         }
       ],
       "packages": [

--- a/method-list/egon-to-client/WriteOrderStatus.md
+++ b/method-list/egon-to-client/WriteOrderStatus.md
@@ -4,47 +4,49 @@ Request to write an order status to the client system.
 
 ## :arrow_forward: Input parameters:
 
-
-| parameter                 |                  |                                    |     format     | description                                                                         |
-|:--------------------------|:-----------------|:-----------------------------------|:--------------:|:------------------------------------------------------------------------------------|
-| `order_original_id`       |                  |                                    |    (String)    | The original order number for the client                                            |
-| `reference_number`        |                  |                                    |    (String)    | Reference Nr. of order                                                              |
-| `order_id`                |                  |                                    |   (Integer)    | Order ID from EGON                                                                  |
-| `status_id`               |                  |                                    |   (Integer)    | EGON status ID                                                                      |
-| `status_name`             |                  |                                    |    (String)    | Status name from EGON                                                               |
-| `api_update_enabled`      |                  |                                    |   (Boolean)    | If update over api in this status is enabled then true otherwise false              |
-| `change_timestamp`        |                  |                                    |   (Datetime)   | Timestamp of state change                                                           |
-| `delivery_id`             |                  |                                    |   (Integer)    | Traffic ID                                                                          |
-| `order_items`             |                  |                                    |    (Object)    | Order items                                                                         |
-|                           | `ITEM_ID`        |                                    |   (Integer)    | ITEM_ID eshop card                                                                  |
-|                           | `COUNT`          |                                    |   (Integer)    | Number of pieces in order                                                           |
-|                           | `COUNT_RESERVED` |                                    |   (Integer)    | Number of reserved pieces in the order                                              |
-| `packages`                |                  |                                    |    (Array)     |                                                                                     |
-|                           | `package_nr`     |                                    |    (String)    | Tracking number                                                                     |
-|                           | `tracking_url`  |                                    |    (String)    | Tracking link                                                                       |
-|                           | `tracking_data`  |                                    |    (Array)     | Field with data from tracking                                                       |
-|                           |                  | `timestamp`                        |   (Datetime)   | Time from state                                                                     |
-|                           |                  | `shipment_status`                  |   (Integer)    | Status code from the codebook                                                       |
-|                           |                  | `shipment_note`                    |    (String)    | The name of the status from the dial                                                |
-|                           |                  | `shipment_status_delivery_company` |    (String)    | Status ID from courier company                                                      |
-|                           |                  | `shipment_note_delivery_company`   |    (String)    | The name of the state from the courier company                                      |
-|                           | `images`         |                                    |    (Array)     | Pictures                                                                            |
-|                           | `weight`         |                                    |   (Integer)    | Weight                                                                              |
-|                           | `width`          |                                    |   (Integer)    | Width                                                                               |
-|                           | `height`         |                                    |   (Integer)    | Height                                                                              |
-|                           | `depth`          |                                    |   (Integer)    | Depth                                                                               |
-|                           | `label`          |                                    |    (String)    | Label                                                                               |
-| `shipp_company_id`        |                  |                                    |   (Integer)    | Id the carrier in the system                                                        |
-| `shipp_company`           |                  |                                    |    (String)    | Shipper                                                                             |
-| `estimated_delivery_time` |                  |                                    |     (Date)     | Assumption date of delivery                                                         |
-| `total_cost`              |                  |                                    |   (Decimal)    | Total expense                                                                       |
-| `cost_by_item`            |                  |                                    |    (Array)     | Costs per individual items                                                          |
-|                           | `item_id`        |                                    |   (Integer)    |                                                                                     |
-|                           | `name`           |                                    |    (String)    |                                                                                     |
-|                           | `price`          |                                    |   (Decimal)    |                                                                                     |
-| `order_errors`            |                  |                                    |    (Array)     | Wrong order parameters                                                              |
-| `invoice_url`             |                  |                                    | (String/null)  | Order invoice url                                                                   |
-| `invoice_id`              |                  |                                    | (Integer/null) | Order invoice id (specific for invoicing system)                                    |                                     |
+| parameter                 |                    |                                    |     format     | description                                                            |
+|:--------------------------|:-------------------|:-----------------------------------|:--------------:|:-----------------------------------------------------------------------|
+| `order_original_id`       |                    |                                    |    (String)    | The original order number for the client                               |
+| `reference_number`        |                    |                                    |    (String)    | Reference Nr. of order                                                 |
+| `order_id`                |                    |                                    |   (Integer)    | Order ID from EGON                                                     |
+| `status_id`               |                    |                                    |   (Integer)    | EGON status ID                                                         |
+| `status_name`             |                    |                                    |    (String)    | Status name from EGON                                                  |
+| `api_update_enabled`      |                    |                                    |   (Boolean)    | If update over api in this status is enabled then true otherwise false |
+| `change_timestamp`        |                    |                                    |   (Datetime)   | Timestamp of state change                                              |
+| `delivery_id`             |                    |                                    |   (Integer)    | Traffic ID                                                             |
+| `order_items`             |                    |                                    |    (Object)    | Order items                                                            |
+|                           | `ITEM_ID`          |                                    |   (Integer)    | ITEM_ID eshop card                                                     |
+|                           | `COUNT`            |                                    |   (Integer)    | Number of pieces in order                                              |
+|                           | `COUNT_RESERVED`   |                                    |   (Integer)    | Number of reserved pieces in the order                                 |
+|                           | `ISSUE_CARD_ITEMS` |                                    |    (Array)     | array of items in issue card                                           |
+|                           |                    | `INVENTORY_ID`                     |   (Integer)    | Inventory ID of the warehouse card                                     |
+|                           |                    | `QR_CODE`                          | (String/null)  | QR code (if have) of he item                                           |
+| `packages`                |                    |                                    |    (Array)     |                                                                        |
+|                           | `package_nr`       |                                    |    (String)    | Tracking number                                                        |
+|                           | `tracking_url`     |                                    |    (String)    | Tracking link                                                          |
+|                           | `tracking_data`    |                                    |    (Array)     | Field with data from tracking                                          |
+|                           |                    | `timestamp`                        |   (Datetime)   | Time from state                                                        |
+|                           |                    | `shipment_status`                  |   (Integer)    | Status code from the codebook                                          |
+|                           |                    | `shipment_note`                    |    (String)    | The name of the status from the dial                                   |
+|                           |                    | `shipment_status_delivery_company` |    (String)    | Status ID from courier company                                         |
+|                           |                    | `shipment_note_delivery_company`   |    (String)    | The name of the state from the courier company                         |
+|                           | `images`           |                                    |    (Array)     | Pictures                                                               |
+|                           | `weight`           |                                    |   (Integer)    | Weight                                                                 |
+|                           | `width`            |                                    |   (Integer)    | Width                                                                  |
+|                           | `height`           |                                    |   (Integer)    | Height                                                                 |
+|                           | `depth`            |                                    |   (Integer)    | Depth                                                                  |
+|                           | `label`            |                                    |    (String)    | Label                                                                  |
+| `shipp_company_id`        |                    |                                    |   (Integer)    | Id the carrier in the system                                           |
+| `shipp_company`           |                    |                                    |    (String)    | Shipper                                                                |
+| `estimated_delivery_time` |                    |                                    |     (Date)     | Assumption date of delivery                                            |
+| `total_cost`              |                    |                                    |   (Decimal)    | Total expense                                                          |
+| `cost_by_item`            |                    |                                    |    (Array)     | Costs per individual items                                             |
+|                           | `item_id`          |                                    |   (Integer)    |                                                                        |
+|                           | `name`             |                                    |    (String)    |                                                                        |
+|                           | `price`            |                                    |   (Decimal)    |                                                                        |
+| `order_errors`            |                    |                                    |    (Array)     | Wrong order parameters                                                 |
+| `invoice_url`             |                    |                                    | (String/null)  | Order invoice url                                                      |
+| `invoice_id`              |                    |                                    | (Integer/null) | Order invoice id (specific for invoicing system)                       |                                     |
 
 ### Sample request
 
@@ -69,7 +71,13 @@ Request to write an order status to the client system.
         {
           "ITEM_ID": 123,
           "COUNT": 1,
-          "COUNT_RESERVED": 1
+          "COUNT_RESERVED": 1,
+          "ISSUE_CARD_ITEMS": [
+            {
+              "INVENTORY_ID": 321,
+              "QR_CODE": "xyz"
+            }
+          ]
         }
       ],
       "packages": [


### PR DESCRIPTION
The order items structure for WriteOrderStatus.md and GetOrderStatus.md has been updated. The changes include adding an array of items in issue card under order items with fields for the inventory ID and QR code. These changes are in line with updates to the relevant API endpoints regarding order items information handling.