### PR TITLE
Updated ShipmentNotify parameters

### DIFF
--- a/method-list/client-to-egon/ShipmentNotify.md
+++ b/method-list/client-to-egon/ShipmentNotify.md
@@ -4,18 +4,19 @@ Method stores (create or update) information about notified shipment
 
 ## :arrow_forward: Input parameters:
 
-| parameter            |            |   format   |                        allowed values                        | mandatory / default value | description                                                             |
-|:---------------------|:-----------|:----------:|:------------------------------------------------------------:|:-------------------------:|:------------------------------------------------------------------------|
-| `shipment_notify_id` |            | (Integer)  |                              -                               |                           | (optional for update) - `shipment_notify_id` return from first response |
-| `shop_setting_id`    |            | (Integer)  | [link](https://egon.isklad.eu/klient/settings-shop-settings) |    :heavy_check_mark:     | Set-to-order setting ID                                                 |
-| `date_from`          |            | (Datetime) |                              -                               |    :heavy_check_mark:     | Delivery date from                                                      |
-| `date_to`            |            | (Datetime) |                              -                               |    :heavy_check_mark:     | Delivery date to                                                        |
-| `tracking_number`    |            |  (String)  |                              -                               |    :heavy_check_mark:     | Tracking number                                                         |
-| `supplier_id`        |            | (Integer)  |                              -                               |    :heavy_check_mark:     | Supplier ID                                                             |
-| `reference_number`   |            |  (String)  |                              -                               |    :heavy_check_mark:     | Reference Nr. of order                                                  |
-| `items`              |            |  (Array)   |                              -                               |    :heavy_check_mark:     | Items                                                                   |
-|                      | `item_id`  | (Integer)  |                              -                               |    :heavy_check_mark:     | Difference inventory card id                                            |
-|                      | `quantity` | (Integer)  |                              -                               |    :heavy_check_mark:     | Difference inventory quantity                                           |
+| parameter            |                   |   format   |                        allowed values                        | mandatory / default value | description                                                             |
+|:---------------------|:------------------|:----------:|:------------------------------------------------------------:|:-------------------------:|:------------------------------------------------------------------------|
+| `shipment_notify_id` |                   | (Integer)  |                              -                               |                           | (optional for update) - `shipment_notify_id` return from first response |
+| `shop_setting_id`    |                   | (Integer)  | [link](https://egon.isklad.eu/klient/settings-shop-settings) |    :heavy_check_mark:     | Set-to-order setting ID                                                 |
+| `date_from`          |                   | (Datetime) |                              -                               |    :heavy_check_mark:     | Delivery date from                                                      |
+| `date_to`            |                   | (Datetime) |                              -                               |    :heavy_check_mark:     | Delivery date to                                                        |
+| `packages`           |                   |  (Array)   |                              -                               |    :heavy_check_mark:     | Array of packages, at least one is mandatory                            |
+|                      | `tracking_number` |  (String)  |                              -                               |    :heavy_check_mark:     | Tracking number of the package (printed as barcode on label)            |
+| `supplier_id`        |                   | (Integer)  |                              -                               |    :heavy_check_mark:     | Supplier ID                                                             |
+| `reference_number`   |                   |  (String)  |                              -                               |    :heavy_check_mark:     | Reference Nr. of order                                                  |
+| `items`              |                   |  (Array)   |                              -                               |    :heavy_check_mark:     | Items                                                                   |
+|                      | `item_id`         | (Integer)  |                              -                               |    :heavy_check_mark:     | Difference inventory card id                                            |
+|                      | `quantity`        | (Integer)  |                              -                               |    :heavy_check_mark:     | Difference inventory quantity                                           |
 
 ### Sample request
 
@@ -35,13 +36,24 @@ Method stores (create or update) information about notified shipment
       "shop_setting_id": 1,
       "date_from": "2022-02-02",
       "date_to": "2022-02-02",
-      "tracking_number": "1234567890",
+      "packages": [
+        {
+          "tracking_number": "1234567890"
+        },
+        {
+          "tracking_number": "0987654321"
+        }
+      ],
       "supplier_id": 100,
-      "reference_number": "ref123",
+      "reference_number": "reference-123",
       "items": [
         {
           "item_id": 1,
           "quantity": 10
+        },
+        {
+          "item_id": 2,
+          "quantity": 20
         }
       ]
     }
@@ -51,9 +63,9 @@ Method stores (create or update) information about notified shipment
 
 ## :arrow_forward: Output parameters:
 
-| parameter            |  format   | description                       |
-|:---------------------|:---------:|:----------------------------------|
-| `shipment_notify_id` | (integer) | created shipment notification ID  |
+| parameter            |  format   | description                      |
+|:---------------------|:---------:|:---------------------------------|
+| `shipment_notify_id` | (integer) | created shipment notification ID |
 
 ### Sample response
 


### PR DESCRIPTION
In the 'ShipmentNotify' endpoint documentation, the input parameters have been updated. 'tracking_number' is moved under 'packages' which is a new mandatory array, tracking numbers are now tied to individual packages. The sample request has been updated to reflect these changes.