### PR TITLE
Add GetShippingLabel method documentation

### DIFF
--- a/.idea/egon-api-documentation.iml
+++ b/.idea/egon-api-documentation.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ See more at [Managing subscriptions and notifications on GitHub](https://docs.gi
   - [UpdatePackageTracking](method-list/egon-to-client/UpdatePackageTracking.md) ![deprecated](/assets/images/deprecated.png)
   - [WriteOrderStatus](method-list/egon-to-client/WriteOrderStatus.md)
   - [MyOrderClaimUpdate](method-list/egon-to-client/MyOrderClaimUpdate.md)
+  - [GetShippingLabel](method-list/egon-to-client/GetShippingLabel.md)
 
 - **Code lists**
   - [Response and error codes](code-lists/response-codes.md)

--- a/method-list/egon-to-client/GetShippingLabel.md
+++ b/method-list/egon-to-client/GetShippingLabel.md
@@ -1,0 +1,108 @@
+# GetShippingLabel
+
+The method is used to obtain the shipping label for the package. If the order has multiple packages, the method returns
+the label for the specified package.
+
+## :arrow_forward: Input parameters:
+
+Associative field with info about package.
+
+| parameter           |                 | format        | description                                         |
+|---------------------|-----------------|---------------|-----------------------------------------------------|
+| `order_id`          |                 | (Integer)     | Order ID in EGON                                    |
+| `original_order_id` |                 | (String)      | Order ID in Eshop                                   |
+| `package`           |                 | (Object)      | Package object                                      |
+|                     | `id`            | (Integer)     | Id in EGON                                          |
+|                     | `width`         | (Integer)     | Width in mm                                         |
+|                     | `height`        | (Integer)     | Height in mm                                        |
+|                     | `depth`         | (Integer)     | Depth in mm                                         |
+|                     | `weight`        | (Integer)     | Weight in g                                         |
+| `cod`               |                 | (Float/null)  | COD (cash on delivery) or null if it is without COD |
+| `currency`          |                 | (String)      | Currency od COD                                     |
+| `note`              |                 | (String/null) | Note from the order                                 |
+| `customer`          |                 | (Object)      | Customer object                                     |
+|                     | `company`       | (String)      | Customer company                                    |
+|                     | `name`          | (String)      | Customer name                                       |
+|                     | `surname`       | (String)      | Customer surname                                    |
+|                     | `street`        | (String)      | Customer street                                     |
+|                     | `street_number` | (String)      | Customer street number                              |
+|                     | `house_number`  | (String/null) | Customer house number                               |
+|                     | `city`          | (String)      | Customer city                                       |
+|                     | `postal_code`   | (String)      | Customer postal code                                |
+|                     | `phone`         | (String)      | Customer phone                                      |
+|                     | `email`         | (String)      | Customer email                                      |
+
+### Sample request
+
+```json
+{
+  "auth": {
+    "auth_id": "AUTH_ID",
+    "auth_key": "AUTH_KEY"
+  },
+  "request": {
+    "req_method": "GetShippingLabel",
+    "req_data": {
+      "order_id": 789654,
+      "order_original_id": "123456",
+      "package": {
+        "id": 123456,
+        "width": 100,
+        "height": 100,
+        "depth": 100,
+        "weight": 1000
+      },
+      "cod": 100.00,
+      "currency": "CZK",
+      "note": "Note from the order",
+      "customer": {
+        "company": "Company",
+        "name": "Name",
+        "surname": "Surname",
+        "street": "Street",
+        "street_number": "123",
+        "house_number": "123",
+        "city": "City",
+        "postal_code": "12345",
+        "phone": "+420123456789",
+        "email": "email@domain.tld"
+      }
+    }
+  }
+}
+```
+
+## :arrow_forward: Output parameters:
+
+Data obtained by decoding JSON format:
+
+| parameter     |                | format        | description                             |
+|---------------|----------------|---------------|-----------------------------------------|
+| `auth_status` |                | (Integer)     | the result code of the authorization    |
+| `response`    |                | (Array)       | response wrapper                        |
+|               | `resp_status`  | (Integer)     | response code                           |
+|               | `awb`          | (String)      | AWB from the label                      |
+|               | `awb_extended` | (String)      | Barcode from the label (extended AWB)   |
+|               | `base_64_pdf`  | (String)      | Label in Base64 format, PDF, 10x15 cm   |
+|               | `tracking_url` | (String/null) | Tracking url for final client if exists |
+
+:bulb: The response codes correspond to the code in
+the [Response and error codes](../../code-lists/response-codes.md#--resp_status-codes)
+section.
+
+### Sample response
+
+The sample answer in the JSON format looks like this:
+
+```json
+{
+  "auth_status": 1,
+  "response": {
+    "resp_status": 1,
+    "awb": "123456789",
+    "awb_extended": "1234567890",
+    "base64pdf": "JVBERi0xLjQKJeLjz9MKMyAwIG9iago8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFIvTGFuZ...",
+    "tracking_url": "https://tracking.url.tld/123456789"
+  }
+}
+```


### PR DESCRIPTION
Introduced the GetShippingLabel method in the API documentation, detailing the input parameters, a sample request, and the expected output parameters. Additionally, added the corresponding entry link in the README file.