### PR TITLE
Add `adult_restricted` field to UpdateInventoryCard.md

### DIFF
--- a/method-list/client-to-egon/UpdateInventoryCard.md
+++ b/method-list/client-to-egon/UpdateInventoryCard.md
@@ -36,7 +36,8 @@ This method modifies (if it already exists) or inserts (if not yet) a product ca
 | `accessories`             |           |  (Array)  |                              -                               |                           | If it is combined card, the field of subcards is sent here   |
 |                           | `item_id` | (Integer) |                              -                               |                           | ITEM_ID of stock card, which belongs under the combined card |
 |                           | `count`   | (Integer) |                              -                               |                           | Count of a stock card, that belongs under the combined card  |
-| `weight_grams`            |           | (Integer) |                              -                               |        default: 0         | Weigh of a product in grams                                  |
+| `weight_grams`            |           | (Integer) |                              -                               |       default: `0`        | Weigh of a product in grams                                  |
+| `adult_restricted`        |           | (Integer) |                              -                               |       default: `0`        | `0` = not restricted, `1` = only for adults                  |
 
 ### Sample requests
 
@@ -121,7 +122,8 @@ This method modifies (if it already exists) or inserts (if not yet) a product ca
           "count": 2
         }
       ],
-      "weight_grams": 100
+      "weight_grams": 100,
+      "adult_restricted": 1
     }
   }
 }


### PR DESCRIPTION
The new `adult_restricted` field indicates whether a product is restricted to adults (`1`) or not (`0`). Updated both the documentation table and sample request to include this optional parameter.