### PR TITLE
Add `paired_packages` parameter to ShipmentNotifyConfirm

### DIFF
--- a/method-list/egon-to-client/ShipmentNotifyConfirm.md
+++ b/method-list/egon-to-client/ShipmentNotifyConfirm.md
@@ -4,20 +4,23 @@ The method stores information about the notified shipment
 
 ## :arrow_forward: Input parameters:
 
-| parameter               |             | format          | description                                                                                     |
-|-------------------------|-------------|-----------------|-------------------------------------------------------------------------------------------------|
-| `shipment_notify_id`    |             | (integer)       | Notification ID, previously received from [ShipmentNotify](../client-to-egon/ShipmentNotify.md) |
-| `shipment_arrived_at`   |             | (datetime/null) | Shipment receive date                                                                           |
-| `shipment_confirmed_at` |             | (datetime/null) | Date of comparison (after pairing of all product cards)                                         |
-| `items`                 |             | (array)         | List of received goods                                                                          |
-|                         | `item_id`   | (integer)       | received inventory card id                                                                      |
-|                         | `quantity`  | (integer)       | received inventory quantity                                                                     |
-| `items_notified`        |             | (array)         | List of pre-advised items                                                                       |
-|                         | `item_id`   | (integer)       | advised inventory card id                                                                       |
-|                         | `quantity`  | (integer)       | advised inventory quantity                                                                      |
-| `differences`           |             | (array)         | The difference between the received and notified list of goods                                  |
-|                         | `item_id`   | (integer)       | difference inventory card id                                                                    |
-|                         | `quantity`  | (integer)       | difference inventory quantity                                                                   |
+| parameter               |                  | format          | description                                                                                     |
+|-------------------------|------------------|-----------------|-------------------------------------------------------------------------------------------------|
+| `shipment_notify_id`    |                  | (integer)       | Notification ID, previously received from [ShipmentNotify](../client-to-egon/ShipmentNotify.md) |
+| `shipment_arrived_at`   |                  | (datetime/null) | Shipment receive date                                                                           |
+| `shipment_confirmed_at` |                  | (datetime/null) | Date of comparison (after pairing of all product cards)                                         |
+| `items`                 |                  | (array)         | List of received goods                                                                          |
+|                         | `item_id`        | (integer)       | received inventory card id                                                                      |
+|                         | `quantity`       | (integer)       | received inventory quantity                                                                     |
+| `items_notified`        |                  | (array)         | List of pre-advised items                                                                       |
+|                         | `item_id`        | (integer)       | advised inventory card id                                                                       |
+|                         | `quantity`       | (integer)       | advised inventory quantity                                                                      |
+| `differences`           |                  | (array)         | The difference between the received and notified list of goods                                  |
+|                         | `item_id`        | (integer)       | difference inventory card id                                                                    |
+|                         | `quantity`       | (integer)       | difference inventory quantity                                                                   |
+| `paired_packages`       |                  | (array)         | List of paired packages/items                                                                   |
+|                         | `package_id`     | (integer)       | package ID                                                                                      |
+|                         | `package_box_id` | (integer)       | package box ID                                                                                  |
 
 ### Sample request
 
@@ -44,7 +47,13 @@ The method stores information about the notified shipment
       "differences": {
         "item_id": 1,
         "quantity": -5
-      }
+      },
+      "paired_packages": [
+        {
+          "package_id": 1,
+          "package_box_id": 1
+        }
+      ]
     }
   }
 }

--- a/method-list/egon-to-client/ShipmentNotifyConfirm.md
+++ b/method-list/egon-to-client/ShipmentNotifyConfirm.md
@@ -4,23 +4,30 @@ The method stores information about the notified shipment
 
 ## :arrow_forward: Input parameters:
 
-| parameter               |                  | format          | description                                                                                     |
-|-------------------------|------------------|-----------------|-------------------------------------------------------------------------------------------------|
-| `shipment_notify_id`    |                  | (integer)       | Notification ID, previously received from [ShipmentNotify](../client-to-egon/ShipmentNotify.md) |
-| `shipment_arrived_at`   |                  | (datetime/null) | Shipment receive date                                                                           |
-| `shipment_confirmed_at` |                  | (datetime/null) | Date of comparison (after pairing of all product cards)                                         |
-| `items`                 |                  | (array)         | List of received goods                                                                          |
-|                         | `item_id`        | (integer)       | received inventory card id                                                                      |
-|                         | `quantity`       | (integer)       | received inventory quantity                                                                     |
-| `items_notified`        |                  | (array)         | List of pre-advised items                                                                       |
-|                         | `item_id`        | (integer)       | advised inventory card id                                                                       |
-|                         | `quantity`       | (integer)       | advised inventory quantity                                                                      |
-| `differences`           |                  | (array)         | The difference between the received and notified list of goods                                  |
-|                         | `item_id`        | (integer)       | difference inventory card id                                                                    |
-|                         | `quantity`       | (integer)       | difference inventory quantity                                                                   |
-| `paired_packages`       |                  | (array)         | List of paired packages/items                                                                   |
-|                         | `package_id`     | (integer)       | package ID                                                                                      |
-|                         | `package_box_id` | (integer)       | package box ID                                                                                  |
+| parameter               |                          | format          | description                                                                                     |
+|-------------------------|--------------------------|-----------------|-------------------------------------------------------------------------------------------------|
+| `shipment_notify_id`    |                          | (integer)       | Notification ID, previously received from [ShipmentNotify](../client-to-egon/ShipmentNotify.md) |
+| `shipment_arrived_at`   |                          | (datetime/null) | Shipment receive date                                                                           |
+| `shipment_confirmed_at` |                          | (datetime/null) | Date of comparison (after pairing of all product cards)                                         |
+| `items`                 |                          | (array)         | List of received goods                                                                          |
+|                         | `warehouse_inventory_id` | (integer)       | received warehouse inventory card id                                                            |
+|                         | `inventory_id`           | (integer/null)  | received inventory card id                                                                      |
+|                         | `item_id`                | (integer/null)  | received inventory card item_id                                                                 |
+|                         | `count`                  | (integer)       | received inventory quantity                                                                     |
+| `items_notified`        |                          | (array)         | List of pre-advised items                                                                       |
+|                         | `inventory_id`           | (integer/null)  | advised inventory card id                                                                       |
+|                         | `item_id`                | (integer/null)  | advised inventory card item_id                                                                  |
+|                         | `count`                  | (integer)       | advised inventory quantity                                                                      |
+| `differences`           |                          | (array)         | The difference between the received and notified list of goods                                  |
+|                         | `warehouse_inventory_id` | (integer/null)  | difference warehouse inventory card id                                                          |
+|                         | `inventory_id`           | (integer/null)  | difference inventory card id                                                                    |
+|                         | `item_id`                | (integer)       | difference inventory card item_id                                                               |
+|                         | `count`                  | (integer)       | difference inventory quantity                                                                   |
+|                         | `countNotified`          | (integer)       | difference inventory quantity notified                                                          |
+|                         | `difference`             | (integer)       | difference quantity                                                                             |
+| `paired_packages`       |                          | (array)         | List of paired packages/items                                                                   |
+|                         | `package_id`             | (integer)       | package ID                                                                                      |
+|                         | `package_box_id`         | (integer)       | package box ID                                                                                  |
 
 ### Sample request
 
@@ -36,18 +43,31 @@ The method stores information about the notified shipment
       "shipment_notify_id": 1,
       "shipment_arrived_at": "2021-01-01 12:31",
       "shipment_confirmed_at": null,
-      "items": {
-        "item_id": 1,
-        "quantity": 10
-      },
-      "items_notified": {
-        "item_id": 1,
-        "quantity": 15
-      },
-      "differences": {
-        "item_id": 1,
-        "quantity": -5
-      },
+      "items": [
+        {
+          "warehouse_inventory_id": 1,
+          "inventory_id": null,
+          "item_id": null,
+          "count": 10
+        }
+      ],
+      "items_notified": [
+        {
+          "inventory_id": 1,
+          "item_id": 1,
+          "count": 15
+        }
+      ],
+      "differences": [
+        {
+          "warehouse_inventory_id": 1,
+          "inventory_id": 1,
+          "item_id": 1,
+          "count": 10,
+          "countNotified": 15,
+          "difference": -5
+        }
+      ],
       "paired_packages": [
         {
           "package_id": 1,


### PR DESCRIPTION
This update introduces the `paired_packages` parameter to include information about paired packages and their IDs. It enhances data comprehensiveness by detailing `package_id` and `package_box_id`, improving shipment tracking accuracy. Documentation adjustments reflect these changes clearly.